### PR TITLE
Add emotional flair

### DIFF
--- a/app/src/main/java/com/example/kkobakkobak/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/kkobakkobak/ui/main/MainActivity.kt
@@ -54,7 +54,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun playTypewriterEffectAndShowMainContent() {
-        val fullText = "꾸박꾸박"
+        val fullText = "꾸준함이 빛나는 공간, 꾸박꾸박"
         appTitleTypewriter.text = ""
         appTitleTypewriter.visibility = View.VISIBLE
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,8 +10,8 @@
     <color name="white">#FFFFFFFF</color>
 
     <!-- 사용자 정의 SmartThings 스타일 색상 -->
-    <color name="gradient_blue_start">#2995F6</color> <!-- 하늘색 -->
-    <color name="gradient_blue_end">#165BAA</color>   <!-- 진한 파랑 -->
+    <color name="gradient_blue_start">#FF9A9E</color> <!-- 파스텔 핑크 -->
+    <color name="gradient_blue_end">#FAD0C4</color>   <!-- 부드러운 피치 -->
     <color name="single_blue">#1A73E8</color>         <!-- 단일 파랑 (액센트) -->
 
     <color name="text_primary_white">#FFFFFF</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,9 +61,9 @@
 
     <!-- 격려 메시지 배열 -->
     <string-array name="encouragement_messages">
-        <item>잊지 말고 꼭 챙겨 드세요!</item>
-        <item>오늘도 건강한 하루!</item>
-        <item>약 먹고 힘내세요!</item>
-        <item>규칙적인 복용이 중요해요!</item>
+        <item>오늘도 당신의 건강을 응원해요!</item>
+        <item>꾸준함 속에 건강이 자라요 :)</item>
+        <item>건강을 위한 소중한 습관, 잊지 마세요!</item>
+        <item>오늘도 빛나는 당신, 약 챙기기도 잊지 마세요!</item>
     </string-array>
 </resources>


### PR DESCRIPTION
## Summary
- brighten up the typewriter intro text
- soften gradient colors
- add more heartfelt encouragement messages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876ec27aae0832ab9aabd1e8ed2f87a