### PR TITLE
Implement missing fragment layouts

### DIFF
--- a/app/src/main/java/com/example/kkobakkobak/ui/completion/CompletionFragment.kt
+++ b/app/src/main/java/com/example/kkobakkobak/ui/completion/CompletionFragment.kt
@@ -13,9 +13,8 @@ class CompletionFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        // 이 프래그먼트의 레이아웃을 인플레이트합니다.
-        // 만약 fragment_completion.xml 레이아웃 파일이 있다면 R.layout.fragment_completion으로 변경해주세요.
-        return inflater.inflate(R.layout.fragment_development, container, false) // 임시로 development 프래그먼트 레이아웃 사용
+        // 완료 화면 레이아웃을 인플레이트합니다.
+        return inflater.inflate(R.layout.fragment_completion, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/example/kkobakkobak/ui/history/LogHistoryFragment.kt
+++ b/app/src/main/java/com/example/kkobakkobak/ui/history/LogHistoryFragment.kt
@@ -13,9 +13,8 @@ class LogHistoryFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        // 이 프래그먼트의 레이아웃을 인플레이트합니다.
-        // 만약 activity_log_history.xml 레이아웃 파일이 있다면 R.layout.activity_log_history로 변경해주세요.
-        return inflater.inflate(R.layout.activity_log_history, container, false) // 임시로 activity_log_history 레이아웃 사용
+        // 기록 내역 프래그먼트 레이아웃을 인플레이트합니다.
+        return inflater.inflate(R.layout.fragment_log_history, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/res/layout/fragment_completion.xml
+++ b/app/src/main/res/layout/fragment_completion.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/scrimBackground"
+    android:clickable="true"
+    android:focusable="true">
+
+    <com.airbnb.lottie.LottieAnimationView
+        android:id="@+id/completion_animation_view"
+        android:layout_width="250dp"
+        android:layout_height="250dp"
+        android:layout_centerInParent="true"
+        app:lottie_rawRes="@raw/checkmark_animation"
+        app:lottie_autoPlay="true"
+        app:lottie_loop="false" />
+
+    <TextView
+        android:id="@+id/completion_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/completion_animation_view"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="16dp"
+        android:text="투약 완료!"
+        android:textColor="?attr/colorOnSurface"
+        android:textSize="24sp"
+        android:textStyle="bold" />
+
+    <Button
+        android:id="@+id/btn_confirm"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:layout_marginBottom="80dp"
+        android:text="확인" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_log_history.xml
+++ b/app/src/main/res/layout/fragment_log_history.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="나의 기록 목록 📜"
+        android:textSize="22sp"
+        android:layout_marginBottom="16dp"
+        android:textStyle="bold"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_log_history"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:listitem="@layout/item_log"/>
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add layout for completion fragment
- add layout for log history fragment
- hook up new layouts in corresponding fragments

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878417be234832ab3df35931192f5b1