### PR TITLE
Fix card colors

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -16,7 +16,8 @@
 
     <color name="text_primary_white">#FFFFFF</color>
     <color name="text_secondary_light_grey">#E0E0E0</color>
-    <color name="card_background_dark_blue">#FFFFFF</color>
+    <!-- 어두운 배경 카드에 사용할 블루 계열 색상 -->
+    <color name="card_background_dark_blue">#1A237E</color>
     <color name="button_background_translucent_white">#33FFFFFF</color> <!-- #FFFFFF with 20% opacity -->
     <color name="button_text_blue">#1A73E8</color>
 


### PR DESCRIPTION
## Summary
- ensure cards use a dark background so white text is readable

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879b5c0ee50832aba5e7b1622faa12c