### PR TITLE
Implement DateUtils for formatted timestamps

### DIFF
--- a/app/src/main/java/com/example/kkobakkobak/ui/medication/MedicationHistoryAdapter.kt
+++ b/app/src/main/java/com/example/kkobakkobak/ui/medication/MedicationHistoryAdapter.kt
@@ -7,9 +7,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.example.kkobakkobak.R
 import com.example.kkobakkobak.data.model.MedicationIntake
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+import com.example.kkobakkobak.util.DateUtils
 
 class MedicationHistoryAdapter(private val intakes: List<MedicationIntake>) :
     RecyclerView.Adapter<MedicationHistoryAdapter.IntakeViewHolder>() {
@@ -28,9 +26,7 @@ class MedicationHistoryAdapter(private val intakes: List<MedicationIntake>) :
     override fun onBindViewHolder(holder: IntakeViewHolder, position: Int) {
         val intake = intakes[position]
         holder.medName.text = intake.medName
-        val date = Date(intake.timestamp)
-        val formatted = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(date)
-        holder.time.text = formatted
+        holder.time.text = DateUtils.formatTimestamp(intake.timestamp)
     }
 
     override fun getItemCount() = intakes.size

--- a/app/src/main/java/com/example/kkobakkobak/util/Constants.kt
+++ b/app/src/main/java/com/example/kkobakkobak/util/Constants.kt
@@ -1,4 +1,5 @@
 package com.example.kkobakkobak.util
 
-class Constants {
+object Constants {
+    const val DATE_TIME_PATTERN = "yyyy년 MM월 dd일 HH시 mm분"
 }

--- a/app/src/main/java/com/example/kkobakkobak/util/DateUtils.kt
+++ b/app/src/main/java/com/example/kkobakkobak/util/DateUtils.kt
@@ -1,4 +1,12 @@
 package com.example.kkobakkobak.util
 
-class DateUtils {
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object DateUtils {
+    fun formatTimestamp(timestamp: Long, pattern: String = Constants.DATE_TIME_PATTERN): String {
+        val sdf = SimpleDateFormat(pattern, Locale.getDefault())
+        return sdf.format(Date(timestamp))
+    }
 }


### PR DESCRIPTION
## Summary
- add a constant for default timestamp pattern
- implement `DateUtils.formatTimestamp`
- reuse the formatter in MedicationHistoryAdapter

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68802c99c59c832ab7e0201b90fcab54